### PR TITLE
Add two optional callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.2.1+1] - 2020-10-07
+- Update README.md
+- Update example/main.dart
+
 ## [0.2.1] - 2020-10-07
 - Make setup optionally async
 - Make tearDown optionally async

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.2.1] - 2020-10-07
+- Make setup optionally async
+- Make tearDown optionally async
+- Make `Phoenix.rebirth()` async
+
 ## [0.2.0] - 2020-06-10
 - Added setup callback
 - Added tearDown callback

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.2.0] - 2020-06-10
+- Added setup callback
+- Added tearDown callback
+
 ## [0.1.0] - 2020-01-08
 - Credit [@rrousselGit](https://github.com/rrousselGit) post on [stackoverflow](https://stackoverflow.com/questions/50115311/flutter-how-to-force-an-application-restart-in-production-mode)
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,19 @@
 
 Easily restart your application from scratch, losing any previous state.
 
+## Installing
+1: Add this to your package's pubspec.yaml file:
+```yaml
+dependencies:
+  flutter_phoenix:
+    git: https://github.com/ludothinking/flutter_phoenix.git
+```
+
+2: Install it
+```bash
+$ flutter pub get
+```
+
 ## Usage
 
 Wrap you App widget in the `Phoenix` widget.

--- a/README.md
+++ b/README.md
@@ -10,25 +10,26 @@ Wrap you App widget in the `Phoenix` widget.
 void main() {
   runApp(
     Phoenix(
+      //Your root widget, usually [MaterialApp], [CupertinoApp] or the widget containing one of them
       child: App(),
-      //Setup callback [Optional]
-      //Invoked everytime [rebirth] is called or the first time the app starts
-      //Can be used to initialize some services in your app, i.g: Your DI container
+      //[Optional] Setup callback
+      //Invoked every time [rebirth] is called or the first time the app starts
+      //Can be used to initialize some services in your app, i.g: Open up a connection to a chat service
       setup: () {
-        //Initialize DI Container
-      }
-      //TearDown callback [Optional]
-      //Invoked everytime [rebirth] is called before the state change
-      //Can be used to dispose of some service or close some a connection
+        //Do setup work
+      },
+      //[Optional] TearDown callback
+      //Invoked every time [rebirth] is called before the state change
+      //Can be used to dispose of some service or close some connection, i.g: Close up a connection to a chat service
       tearDown: () {
-        //Close chat connection
-      }
+        //Do tear down work
+      },
     ),
   );
 }
 ```
 
-Call the `rebirth` static method when you want to restart your application (rebuild the entire widget tree from scratch).
+Call the `rebirth` static method when you want to restart your application. This will rebuild the entire widget tree from scratch.
 
 
 ```dart
@@ -54,7 +55,7 @@ Here is a non-exhaustive list of use cases where `Phoenix` can help :
 Add the package as a dependency in your pubspec.yaml file.
 ```yaml
 dependencies:
-  flutter_phoenix: "^0.1.0"
+  flutter_phoenix: "^0.2.0"
 ```
 
 ### Import

--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@ void main() {
   runApp(
     Phoenix(
       child: App(),
+      //Setup callback [Optional]
+      //Invoked everytime [rebirth] is called or the first time the app starts
+      //Can be used to initialize some services in your app, i.g: Your DI container
+      setup: () {
+        //Initialize DI Container
+      }
+      //TearDown callback [Optional]
+      //Invoked everytime [rebirth] is called before the state change
+      //Can be used to dispose of some service or close some a connection
+      tearDown: () {
+        //Close chat connection
+      }
     ),
   );
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -50,7 +50,11 @@ class _SplashScreenState extends State<SplashScreen> {
           children: <Widget>[
             Text(
               'Initial Screen',
-              style: TextStyle(color: Colors.white, fontSize: 34, fontWeight: FontWeight.w700),
+              style: TextStyle(
+                color: Colors.white,
+                fontSize: 34,
+                fontWeight: FontWeight.w700,
+              ),
             ),
           ],
         ),
@@ -61,7 +65,7 @@ class _SplashScreenState extends State<SplashScreen> {
   Future<Timer> simulateInitialDataLoading() async {
     return Timer(
       const Duration(seconds: 2),
-          () => Navigator.push(
+      () => Navigator.push(
         context,
         MaterialPageRoute(
           builder: (context) => const MainScreen(),
@@ -88,7 +92,10 @@ class MainScreen extends StatelessWidget {
             children: <Widget>[
               Text(
                 'Flutter Phoenix',
-                style: TextStyle(fontSize: 34, fontWeight: FontWeight.w700),
+                style: TextStyle(
+                  fontSize: 34,
+                  fontWeight: FontWeight.w700,
+                ),
               ),
               const SizedBox(height: 24),
               Text(
@@ -97,7 +104,11 @@ class MainScreen extends StatelessWidget {
                 '\n\nUsage is fairly simple :'
                 '\n\n1. Wrap your root App widget in the Phoenix widget'
                 '\n\n2. Call Phoenix.rebirth(context); when you want to rebuild your application',
-                style: TextStyle(fontSize: 16, fontWeight: FontWeight.w400, height: 1.5),
+                style: TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.w400,
+                  height: 1.5,
+                ),
               ),
               const Spacer(),
               SizedBox(
@@ -107,6 +118,7 @@ class MainScreen extends StatelessWidget {
                   color: Colors.red,
                   textColor: Colors.white,
                   child: const Text('Phoenix.rebirth(context);'),
+
                   /// 2. Call Phoenix.rebirth(context) to rebuild your app
                   onPressed: () => Phoenix.rebirth(context),
                 ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -48,7 +48,7 @@ class _SplashScreenState extends State<SplashScreen> {
           mainAxisAlignment: MainAxisAlignment.center,
           crossAxisAlignment: CrossAxisAlignment.center,
           children: <Widget>[
-            Text(
+            const Text(
               'Initial Screen',
               style: TextStyle(
                 color: Colors.white,
@@ -90,7 +90,7 @@ class MainScreen extends StatelessWidget {
             mainAxisAlignment: MainAxisAlignment.center,
             crossAxisAlignment: CrossAxisAlignment.start,
             children: <Widget>[
-              Text(
+              const Text(
                 'Flutter Phoenix',
                 style: TextStyle(
                   fontSize: 34,
@@ -98,7 +98,7 @@ class MainScreen extends StatelessWidget {
                 ),
               ),
               const SizedBox(height: 24),
-              Text(
+              const Text(
                 'The Phoenix widget enables you to rebuild your widget tree from scratch, losing any state.'
                 '\n\nIt basically rebuild your whole application.'
                 '\n\nUsage is fairly simple :'

--- a/lib/flutter_phoenix.dart
+++ b/lib/flutter_phoenix.dart
@@ -1,20 +1,22 @@
 library flutter_phoenix;
 
+import 'dart:async';
+
 import 'package:flutter/widgets.dart';
 
 /// Wrap your root App widget in this widget and call [Phoenix.rebirth] to restart your app.
 class Phoenix extends StatefulWidget {
   final Widget child;
-  final VoidCallback setup;
-  final VoidCallback tearDown;
+  final FutureOr<void> Function() setup;
+  final FutureOr<void> Function() tearDown;
 
   Phoenix({@required this.child, this.setup, this.tearDown});
 
   @override
   _PhoenixState createState() => _PhoenixState();
 
-  static rebirth(BuildContext context) {
-    context.findAncestorStateOfType<_PhoenixState>().restartApp();
+  static Future rebirth(BuildContext context) {
+    return context.findAncestorStateOfType<_PhoenixState>().restartApp();
   }
 }
 
@@ -28,14 +30,14 @@ class _PhoenixState extends State<Phoenix> {
     widget?.setup();
   }
 
-  void restartApp() {
-    widget?.tearDown();
+  Future restartApp() async {
+    await widget?.tearDown();
 
     setState(() {
       _key = UniqueKey();
     });
 
-    widget?.setup();
+    await widget?.setup();
   }
 
   @override

--- a/lib/flutter_phoenix.dart
+++ b/lib/flutter_phoenix.dart
@@ -5,8 +5,10 @@ import 'package:flutter/widgets.dart';
 /// Wrap your root App widget in this widget and call [Phoenix.rebirth] to restart your app.
 class Phoenix extends StatefulWidget {
   final Widget child;
+  final VoidCallback setup;
+  final VoidCallback tearDown;
 
-  Phoenix({this.child});
+  Phoenix({@required this.child, this.setup, this.tearDown});
 
   @override
   _PhoenixState createState() => _PhoenixState();
@@ -19,10 +21,21 @@ class Phoenix extends StatefulWidget {
 class _PhoenixState extends State<Phoenix> {
   Key _key = UniqueKey();
 
+  @override
+  void initState() {
+    super.initState();
+
+    widget?.setup();
+  }
+
   void restartApp() {
+    widget?.tearDown();
+
     setState(() {
       _key = UniqueKey();
     });
+
+    widget?.setup();
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_phoenix
 description: Easily restart your application from scratch, losing any previous state
-version: 0.2.1
+version: 0.2.1+1
 homepage: https://github.com/mobiten/flutter_phoenix
 repository: https://github.com/mobiten/flutter_phoenix
 issue_tracker: https://github.com/mobiten/flutter_phoenix/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_phoenix
 description: Easily restart your application from scratch, losing any previous state
-version: 0.1.0
+version: 0.2.0
 homepage: https://github.com/mobiten/flutter_phoenix
 repository: https://github.com/mobiten/flutter_phoenix
 issue_tracker: https://github.com/mobiten/flutter_phoenix/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_phoenix
 description: Easily restart your application from scratch, losing any previous state
-version: 0.2.0
+version: 0.2.1
 homepage: https://github.com/mobiten/flutter_phoenix
 repository: https://github.com/mobiten/flutter_phoenix
 issue_tracker: https://github.com/mobiten/flutter_phoenix/issues


### PR DESCRIPTION
Hello @MrLepage.

This PR adds two callbacks that can be used as a sort of life cycle hook, a `setup` that is called when the starts or is restarted, and another one that is called just before "resetting" the app. I've added those because my app needs those hooks and I thought it would be a good addition to the plugin. I've also updated the README to explain a bit how to use them.

Feel free to ask for any changes if you judge necessary, or to reject it.